### PR TITLE
User Metadata Download Option

### DIFF
--- a/AccountDownloader/Properties/Resources.Designer.cs
+++ b/AccountDownloader/Properties/Resources.Designer.cs
@@ -574,6 +574,15 @@ namespace AccountDownloader.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User Metadata.
+        /// </summary>
+        public static string UserMetadata {
+            get {
+                return ResourceManager.GetString("UserMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Username.
         /// </summary>
         public static string Username {

--- a/AccountDownloader/Properties/Resources.de.resx
+++ b/AccountDownloader/Properties/Resources.de.resx
@@ -187,6 +187,9 @@
   <data name="Username" xml:space="preserve">
     <value>Benutzername</value>
   </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>Benutzer-Metadaten</value>
+  </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>Was möchtest du herunterladen?</value>
   </data>

--- a/AccountDownloader/Properties/Resources.es.resx
+++ b/AccountDownloader/Properties/Resources.es.resx
@@ -258,6 +258,9 @@
   <data name="Username" xml:space="preserve">
     <value>Usuario</value>
   </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>Metadatos de Usuario</value>
+  </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>¿Que te gustaría descargar?</value>
   </data>

--- a/AccountDownloader/Properties/Resources.fr.resx
+++ b/AccountDownloader/Properties/Resources.fr.resx
@@ -258,6 +258,9 @@
   <data name="Username" xml:space="preserve">
     <value>Utilisateur</value>
   </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>Métadonnées Utilisateur</value>
+  </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>Que voulez-vous télécharger?</value>
   </data>

--- a/AccountDownloader/Properties/Resources.ja.resx
+++ b/AccountDownloader/Properties/Resources.ja.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -195,6 +195,9 @@
   </data>
   <data name="Username" xml:space="preserve">
     <value>ユーザー名:</value>
+  </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>ユーザーメタデータ</value>
   </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>何をダウンロードしたいですか?</value>

--- a/AccountDownloader/Properties/Resources.ko.resx
+++ b/AccountDownloader/Properties/Resources.ko.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -195,6 +195,9 @@
   </data>
   <data name="Username" xml:space="preserve">
     <value>사용자 이름:</value>
+  </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>사용자 메타데이터</value>
   </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>무엇을 다운로드하시겠습니까?!</value>

--- a/AccountDownloader/Properties/Resources.resx
+++ b/AccountDownloader/Properties/Resources.resx
@@ -258,6 +258,9 @@
   <data name="Username" xml:space="preserve">
     <value>Username</value>
   </data>
+  <data name="UserMetadata" xml:space="preserve">
+    <value>User Metadata</value>
+  </data>
   <data name="WhatDownload" xml:space="preserve">
     <value>What would you like to Download?</value>
   </data>

--- a/AccountDownloader/Services/AccountDownloadManager.cs
+++ b/AccountDownloader/Services/AccountDownloadManager.cs
@@ -112,6 +112,7 @@ public class AccountDownloadManager : IAccountDownloader
         {
             DownloadCloudVariableDefinitions = config.CloudVariableDefinitions,
             DownloadCloudVariables = config.CloudVariableValues,
+            DownloadUserMetadata = config.UserMetadata,
             DownloadContacts = config.Contacts,
             DownloadMessageHistory = config.MessageHistory,
             DownloadUserRecords = config.InventoryWorlds,

--- a/AccountDownloader/Services/Interfaces/IAppCloudService.cs
+++ b/AccountDownloader/Services/Interfaces/IAppCloudService.cs
@@ -72,6 +72,7 @@ namespace AccountDownloader.Services
 
     public interface IAccountDownloadConfig: IReactiveNotifyPropertyChanged<IReactiveObject>
     {
+        public bool UserMetadata { get; }
         public bool Contacts { get; }
         public bool MessageHistory { get; }
         public bool InventoryWorlds { get; }

--- a/AccountDownloader/ViewModels/DownloadSelectionViewModel.cs
+++ b/AccountDownloader/ViewModels/DownloadSelectionViewModel.cs
@@ -29,6 +29,9 @@ public class DownloadSelectionViewModel : ViewModelBase, IAccountDownloadConfig
     // IAccountDownloadConfig stuff
     // Is bound from the UI to select what data to download
     [Reactive]
+    public bool UserMetadata { get; set; } = false;
+
+    [Reactive]
     public bool Contacts { get; set; } = false;
 
     private bool PreviousMessageHistory = false;
@@ -79,12 +82,13 @@ public class DownloadSelectionViewModel : ViewModelBase, IAccountDownloadConfig
 
         // This is kinda gross
         var hasDownloadSelection = this.WhenAnyValue(
+            x => x.UserMetadata,
             x => x.Contacts,
             x => x.MessageHistory,
             x => x.InventoryWorlds,
             x => x.CloudVariableDefinitions,
             x => x.CloudVariableValues,
-            (contacts, messagehistory, inventoryWorlds, cloudVariableDefinitions, cloudVariableValues) => contacts || messagehistory || inventoryWorlds || cloudVariableDefinitions || cloudVariableValues
+            (userMetadata, contacts, messagehistory, inventoryWorlds, cloudVariableDefinitions, cloudVariableValues) => userMetadata || contacts || messagehistory || inventoryWorlds || cloudVariableDefinitions || cloudVariableValues
         );
         var hasFilePath = this.WhenAnyValue(x => x.FilePath, filePath => !string.IsNullOrEmpty(filePath));
 

--- a/AccountDownloader/Views/DownloadSelectionView.axaml
+++ b/AccountDownloader/Views/DownloadSelectionView.axaml
@@ -13,8 +13,9 @@
         <v:UserProfileView Name="Profile" DataContext="{Binding ProfileViewModel}"></v:UserProfileView>
         <TextBlock Text="{x:Static p:Resources.WhatDownload}" FontSize="16"/>
         <StackPanel>
+            <CheckBox IsChecked="{Binding UserMetadata}" Content="{x:Static p:Resources.UserMetadata}"></CheckBox>
             <CheckBox IsChecked="{Binding Contacts}" Content="{x:Static p:Resources.Contacts}"></CheckBox>
-			<CheckBox IsEnabled="{Binding Contacts}" Margin="15,0,0,0" IsChecked="{Binding MessageHistory}" Content="{x:Static p:Resources.MessageHistory}"></CheckBox>
+			      <CheckBox IsEnabled="{Binding Contacts}" Margin="15,0,0,0" IsChecked="{Binding MessageHistory}" Content="{x:Static p:Resources.MessageHistory}"></CheckBox>
             <CheckBox IsChecked="{Binding InventoryWorlds}" Content="{x:Static p:Resources.InventoryWorlds}"></CheckBox>
             <CheckBox IsChecked="{Binding CloudVariableDefinitions}" Content="{x:Static p:Resources.CloudVariableDefinitions}"></CheckBox>
             <CheckBox IsChecked="{Binding CloudVariableValues}" Content="{x:Static p:Resources.CloudVariableValues}"></CheckBox>

--- a/AccountDownloaderLibrary/AccountDownloadController.cs
+++ b/AccountDownloaderLibrary/AccountDownloadController.cs
@@ -396,7 +396,7 @@ namespace AccountDownloaderLibrary
             SetProgressMessage("Downloading user metadata");
 
             var userMetadata = source.GetUserMetadata();
-            target.StoreUserMetadata(userMetadata);
+            await target.StoreUserMetadata(userMetadata);
         }
 
         public async Task DownloadContacts(CancellationToken cancellationToken)

--- a/AccountDownloaderLibrary/AccountDownloadController.cs
+++ b/AccountDownloaderLibrary/AccountDownloadController.cs
@@ -74,6 +74,10 @@ namespace AccountDownloaderLibrary
 
                 Status.CurrentlyDownloadingName = source.Username;
 
+                // Status.Phase for this step is set in the method
+                if (config.DownloadUserMetadata)
+                    await DownloadUserMetadata(cancellationToken).ConfigureAwait(false);
+
                 // Status.Phase for this step is set in DownloadContacts
                 if (config.DownloadContacts)
                     await DownloadContacts(cancellationToken).ConfigureAwait(false);
@@ -384,6 +388,15 @@ namespace AccountDownloaderLibrary
             await recordProcessing.Completion.ConfigureAwait(false);
 
             SetProgressMessage($"Downloaded {count} records.");
+        }
+
+        public async Task DownloadUserMetadata(CancellationToken cancellationToken)
+        {
+            Status.Phase = "User Metadata";
+            SetProgressMessage("Downloading user metadata");
+
+            var userMetadata = source.GetUserMetadata();
+            target.StoreUserMetadata(userMetadata);
         }
 
         public async Task DownloadContacts(CancellationToken cancellationToken)

--- a/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
@@ -192,6 +192,8 @@ namespace AccountDownloaderLibrary
             }
         }
 
+        public virtual User GetUserMetadata() => Cloud.CurrentUser;
+
         public virtual async Task<List<CloudVariableDefinition>> GetVariableDefinitions(string ownerId)
         {
             var definitions = await Cloud.ListVariableDefinitions(ownerId).ConfigureAwait(false);

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -111,6 +111,8 @@ namespace AccountDownloaderLibrary
             });
         }
 
+        public User GetUserMetadata() => GetEntity<User>(UserMetadataPath(UserId));
+
         public Task<List<Friend>> GetContacts() => GetEntities<Friend>(ContactsPath(UserId));
 
         public async IAsyncEnumerable<Message> GetMessages(string contactId, DateTime? from)
@@ -226,6 +228,8 @@ namespace AccountDownloaderLibrary
                 await StoreEntity(variable, Path.Combine(VariablePath(variable.VariableOwnerId), variable.Path)).ConfigureAwait(false);
         }
 
+        public Task StoreUserMetadata(User user) => StoreEntity(user, Path.Combine(UserMetadataPath(user.Id)));
+
         public Task StoreContact(Friend cotnact) => StoreEntity(cotnact, Path.Combine(ContactsPath(cotnact.OwnerId), cotnact.FriendUserId));
 
         public Task StoreMessage(Message message) => StoreEntity(message, Path.Combine(MessagesPath(message.OwnerId, message.GetOtherUserId()), message.Id));
@@ -273,6 +277,7 @@ namespace AccountDownloaderLibrary
 
         string VariableDefinitionPath(string ownerId) => Path.Combine(BasePath, ownerId, "VariableDefinitions");
         string VariablePath(string ownerId) => Path.Combine(BasePath, ownerId, "Variables");
+        string UserMetadataPath(string ownerId) => Path.Combine(BasePath, ownerId, "User");
         string ContactsPath(string ownerId) => Path.Combine(BasePath, ownerId, "Contacts");
         string MessagesPath(string ownerId, string contactId) => Path.Combine(BasePath, ownerId, "Messages", contactId);
         string RecordsPath(string ownerId) => Path.Combine(BasePath, ownerId, "Records");

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -63,6 +63,7 @@ namespace AccountDownloaderLibrary
         Task<List<MemberData>> GetMembers(string groupId);
         Task<Record> GetRecord(string ownerId, string recordId);
         IAsyncEnumerable<Record> GetRecords(string ownerId, DateTime? from);
+        User GetUserMetadata();
         Task<List<Friend>> GetContacts();
         IAsyncEnumerable<Message> GetMessages(string contactId, DateTime? from);
         Task<DateTime?> GetLatestRecordTime(string ownerId);
@@ -76,6 +77,7 @@ namespace AccountDownloaderLibrary
         Task StoreGroup(Group group, Storage storage);
         Task StoreMember(Group group, Member member, Storage storage);
         Task<string> StoreRecord(Record record, IAccountDataGatherer source, RecordStatusCallbacks statusCallbacks = null, bool forceConflictOverwrite = false);
+        Task StoreUserMetadata(User user);
         Task StoreContact(Friend friend);
         Task StoreMessage(Message message);
     }

--- a/AccountDownloaderLibrary/Models/AccountDownloadConfig.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadConfig.cs
@@ -3,6 +3,11 @@
     public class AccountDownloadConfig
     {
         /// <summary>
+        /// Should user metadata be downloaded?
+        /// </summary>
+        public bool DownloadUserMetadata { get; set; } = true;
+
+        /// <summary>
         /// Should contacts be downloaded?
         /// </summary>
         public bool DownloadContacts { get; set; } = true;


### PR DESCRIPTION
While reviewing the tool, I noticed that the user metadata was not being saved within the account download directory. Since you are already retrieved the Neos User object, I added additional functionality to save the user metadata as well as an opt-in to save save data (exactly the same method as the other types).

User metadata includes standard account information, badges (tags), profile details, Patreon transactions, and other account information. I believe tags include the neosdb id for "custom badges," but I did not check and did not include such functionality to grab these custom badge images.