### PR TITLE
fix(totp-view): address invalid totp and credential flow

### DIFF
--- a/AccountDownloader/ViewModels/Authentication/MultiFactorAuthViewModel.cs
+++ b/AccountDownloader/ViewModels/Authentication/MultiFactorAuthViewModel.cs
@@ -38,7 +38,7 @@ public class MultiFactorAuthViewModel : ViewModelBase, IValidatableViewModel
         {
             if (result.state == AuthenticationState.TOTPRequired)
             {
-                await ShowError.Handle("Invalid TOTP Token");
+                await GlobalInteractions.ShowError.Handle(new MessageBoxRequest("Invalid TOTP Token."));
                 return;
             }
             if (result.state == AuthenticationState.Authenticated)
@@ -47,7 +47,8 @@ public class MultiFactorAuthViewModel : ViewModelBase, IValidatableViewModel
                 return;
             }
 
-            await ShowError.Handle(result.error);
+            await GlobalInteractions.ShowError.Handle(new MessageBoxRequest(result.error ?? "An unknown error occurred when entering TOTP token."));
+
         });
     }
 }

--- a/AccountDownloader/ViewModels/Authentication/MultiFactorAuthViewModel.cs
+++ b/AccountDownloader/ViewModels/Authentication/MultiFactorAuthViewModel.cs
@@ -8,6 +8,7 @@ using Splat;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.Extensions;
 using System.Reactive.Linq;
+using AccountDownloader.Utilities;
 
 namespace AccountDownloader.ViewModels;
 
@@ -49,6 +50,9 @@ public class MultiFactorAuthViewModel : ViewModelBase, IValidatableViewModel
 
             await GlobalInteractions.ShowError.Handle(new MessageBoxRequest(result.error ?? "An unknown error occurred when entering TOTP token."));
 
+            // We have to return back to the login screen as regular username and password credentials are not checked until after the TOTP
+            // token is entered correctly. (WHY? This is bad! Neos should check username and password BEFORE proceeding to the one-time password)
+            await Router.Navigate.Execute(new LoginViewModel());
         });
     }
 }


### PR DESCRIPTION
This pull request addresses issue #28 posted by @SectOLT and another issue I found when TOTP is entered correctly but the password from the previous screen was not.

* When the TOTP is entered incorrectly, the app will freeze and then crash. This is due to the fact that a dedicated message box was being used instead of the global one that was established in the app. I switched to use the global message box instead.
* When the TOTP is entered correctly AND the password from the previous screen was entered incorrectly, the error regarding invalid credentials is shown. However, the screen does not progress back to the Login screen. You have to go back to the Login screen to re-enter your password as well as enter a new TOTP. This is unfortunately how Neos functions as it does not check the username and password before proceeding to TOTP. Neos has implemented this process in a backwards way and, in my honest opinion, produced a small data leak as you now know the account has 2FA without needing the account's password.