### PR TITLE
Failure view enhancements

### DIFF
--- a/AccountDownloader/Properties/Resources.Designer.cs
+++ b/AccountDownloader/Properties/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace AccountDownloader.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hash.
+        /// </summary>
+        public static string AssetHash {
+            get {
+                return ResourceManager.GetString("AssetHash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Assets.
         /// </summary>
         public static string Assets {
@@ -543,6 +552,15 @@ namespace AccountDownloader.Properties {
         public static string RecordPath {
             get {
                 return ResourceManager.GetString("RecordPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Records.
+        /// </summary>
+        public static string Records {
+            get {
+                return ResourceManager.GetString("Records", resourceCulture);
             }
         }
         

--- a/AccountDownloader/Properties/Resources.Designer.cs
+++ b/AccountDownloader/Properties/Resources.Designer.cs
@@ -187,7 +187,7 @@ namespace AccountDownloader.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your download failed to aquire some records, you can find their details below, or see the logs for more information..
+        ///   Looks up a localized string similar to Your download failed to aquire some records or assets, you can find their details below, or see the logs for more information..
         /// </summary>
         public static string DownloadCompleteRecordFailureDescription {
             get {
@@ -205,7 +205,7 @@ namespace AccountDownloader.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rate (Items/Worlds per minute).
+        ///   Looks up a localized string similar to Rate (Records per minute).
         /// </summary>
         public static string DownloadRate {
             get {

--- a/AccountDownloader/Properties/Resources.resx
+++ b/AccountDownloader/Properties/Resources.resx
@@ -271,7 +271,7 @@
     <value>Yes</value>
   </data>
   <data name="DownloadRate" xml:space="preserve">
-    <value>Rate (Items/Worlds per minute)</value>
+    <value>Rate (Records per minute)</value>
   </data>
   <data name="DownloadComplete" xml:space="preserve">
     <value>Download Complete!</value>
@@ -283,7 +283,7 @@
     <value>Your download is complete. Below is a report detailing some statistics from the download. A copy of this has also been written to a log files.</value>
   </data>
   <data name="DownloadCompleteRecordFailureDescription" xml:space="preserve">
-    <value>Your download failed to aquire some records, you can find their details below, or see the logs for more information.</value>
+    <value>Your download failed to aquire some records or assets, you can find their details below, or see the logs for more information.</value>
   </data>
   <data name="UserRecords" xml:space="preserve">
     <value>User Records</value>

--- a/AccountDownloader/Properties/Resources.resx
+++ b/AccountDownloader/Properties/Resources.resx
@@ -315,4 +315,10 @@
   <data name="WithContributionsFrom" xml:space="preserve">
     <value>With contributions from:</value>
   </data>
+  <data name="AssetHash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Records" xml:space="preserve">
+    <value>Records</value>
+  </data>
 </root>

--- a/AccountDownloader/Utilities/DesignData.cs
+++ b/AccountDownloader/Utilities/DesignData.cs
@@ -3,6 +3,7 @@ using AccountDownloader.Utilities;
 using AccountDownloader.ViewModels;
 using AccountDownloaderLibrary;
 using CloudX.Shared;
+using DynamicData;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using System;
@@ -59,7 +60,7 @@ namespace AccountDownloader
     }
     public class DesignData
     {
-        public static List<RecordDownloadFailure> GenerateFailList()
+        public static List<RecordDownloadFailure> GenerateRecordFailList()
         {
             var list = new List<RecordDownloadFailure>();
 
@@ -76,7 +77,18 @@ namespace AccountDownloader
             }
             return list;
         }
-        public static readonly FailedRecordsViewModel DesignFailedRecordsViewModel = new(GenerateFailList());
+        public static readonly FailedRecordsViewModel DesignFailedRecordsViewModel = new(GenerateRecordFailList(), GenerateAssetFailList());
+
+        private static List<AssetFailure> GenerateAssetFailList()
+        {
+            var list = new List<AssetFailure>();
+            for (var i = 0; i < 10; i++)
+            {
+                list.Add(new AssetFailure("1234566sodijosdijfoisdjofijsdf9ij", "Asset failed to download", null));
+            }
+            return list;
+        }
+
         public static readonly UserProfileViewModel DesignProfileViewModel = new(new DesignUserProfile());
         private static readonly List<GroupRecord> _groups = new() {
             new GroupRecord("G-Group0", "Group 1 with Long Name", false, new DesignStorageRecord()),

--- a/AccountDownloader/ViewModels/CompleteViewModel.cs
+++ b/AccountDownloader/ViewModels/CompleteViewModel.cs
@@ -20,22 +20,20 @@ namespace AccountDownloader.ViewModels
 
         public ReactiveCommand<Unit, IRoutableViewModel> StartAnotherDownload { get; }
         public ReactiveCommand<Unit, Unit> Exit { get; }
-
-        // As Status is now essentially "Static" we can setup some static props for it, that make rendering useful
-        public bool HasFailedRecords => Status.TotalFailedRecordCount > 0;
         public CompleteViewModel(IAccountDownloadConfig config, AccountDownloadStatus status)
         {
             Status = status;
             Config = config;
             ProgressStatistics = new ProgressStatisticsViewModel(config, status);
 
+            // Zip up all the records that have failed
             List<RecordDownloadFailure> list = new(status.UserRecordsStatus.FailedRecords);
             foreach (var g in Status.GroupStatuses)
             {
                 list.AddRange(g.RecordsStatus.FailedRecords);
             }
 
-            FailedRecords = new FailedRecordsViewModel(status.UserRecordsStatus.FailedRecords);
+            FailedRecords = new FailedRecordsViewModel(list);
 
             StartAnotherDownload = ReactiveCommand.CreateFromObservable(() => Router.Navigate.Execute(new DownloadSelectionViewModel()));
             Exit = ReactiveCommand.Create(ExitFn);

--- a/AccountDownloader/ViewModels/CompleteViewModel.cs
+++ b/AccountDownloader/ViewModels/CompleteViewModel.cs
@@ -3,6 +3,7 @@ using AccountDownloaderLibrary;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
 using System.Collections.Generic;
 using System.Reactive;
 
@@ -17,6 +18,9 @@ namespace AccountDownloader.ViewModels
         public ProgressStatisticsViewModel ProgressStatistics { get; }
 
         public FailedRecordsViewModel FailedRecords { get; }
+
+        [Reactive]
+        public bool ShouldShowFailureMessage { get; set; } = false;
 
         public ReactiveCommand<Unit, IRoutableViewModel> StartAnotherDownload { get; }
         public ReactiveCommand<Unit, Unit> Exit { get; }
@@ -34,6 +38,9 @@ namespace AccountDownloader.ViewModels
             }
 
             FailedRecords = new FailedRecordsViewModel(list);
+
+            if (list.Count > 0 || Status.AssetFailures.Count > 0)
+                ShouldShowFailureMessage = true;
 
             StartAnotherDownload = ReactiveCommand.CreateFromObservable(() => Router.Navigate.Execute(new DownloadSelectionViewModel()));
             Exit = ReactiveCommand.Create(ExitFn);

--- a/AccountDownloader/ViewModels/CompleteViewModel.cs
+++ b/AccountDownloader/ViewModels/CompleteViewModel.cs
@@ -37,7 +37,7 @@ namespace AccountDownloader.ViewModels
                 list.AddRange(g.RecordsStatus.FailedRecords);
             }
 
-            FailedRecords = new FailedRecordsViewModel(list);
+            FailedRecords = new FailedRecordsViewModel(list, Status.AssetFailures);
 
             if (list.Count > 0 || Status.AssetFailures.Count > 0)
                 ShouldShowFailureMessage = true;

--- a/AccountDownloader/ViewModels/Controls/FailedRecordsViewModel.cs
+++ b/AccountDownloader/ViewModels/Controls/FailedRecordsViewModel.cs
@@ -3,17 +3,21 @@ using System.Collections.ObjectModel;
 using AccountDownloaderLibrary;
 using ReactiveUI;
 
-namespace AccountDownloader.ViewModels
-{
-    public class FailedRecordsViewModel : ReactiveObject
-    {
-        public ObservableCollection<RecordDownloadFailure> FailedRecords {get;}
-        public bool ShouldShow { get; }
+namespace AccountDownloader.ViewModels;
 
-        public FailedRecordsViewModel(List<RecordDownloadFailure> failures)
-        {
-            FailedRecords = new ObservableCollection<RecordDownloadFailure>(failures);
-            ShouldShow = FailedRecords.Count > 0;
-        }
-	}
+// TODO: Collate all failures into a single model, I hated duplicating the work here.
+public class FailedRecordsViewModel : ReactiveObject
+{
+    public ObservableCollection<RecordDownloadFailure> FailedRecords {get;}
+    public ObservableCollection<AssetFailure> FailedAssets { get; }
+    public bool ShouldShowRecordFailures { get; }
+    public bool ShouldShowAssetFailures { get; }
+
+    public FailedRecordsViewModel(List<RecordDownloadFailure> recordFailures, List<AssetFailure> assetFailures)
+    {
+        FailedRecords = new ObservableCollection<RecordDownloadFailure>(recordFailures);
+        FailedAssets = new ObservableCollection<AssetFailure>(assetFailures);
+        ShouldShowRecordFailures = FailedRecords.Count > 0;
+        ShouldShowAssetFailures = FailedAssets.Count > 0;
+    }
 }

--- a/AccountDownloader/Views/CompleteView.axaml
+++ b/AccountDownloader/Views/CompleteView.axaml
@@ -13,7 +13,7 @@
     <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" Text="{x:Static p:Resources.DownloadCompleteDescription}"/>
     <v:ProgressStatisticsView DataContext="{Binding ProgressStatistics}" HorizontalAlignment="Center"/>
     <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" IsVisible="{Binding ShouldShowFailureMessage}" Text="{x:Static p:Resources.DownloadCompleteRecordFailureDescription}" />
-    <ScrollViewer Height="150" IsVisible="{Binding FailedRecords.ShouldShow}" HorizontalAlignment="Center">
+    <ScrollViewer Height="150" IsVisible="{Binding ShouldShowFailureMessage}" HorizontalAlignment="Center" AllowAutoHide="False">
       <v:FailedRecordsView DataContext="{Binding FailedRecords}" HorizontalAlignment="Center"/>
     </ScrollViewer>
     <TextBlock HorizontalAlignment="Center" Text="{x:Static p:Resources.WouldYouLikeToStartAnotherDownload}" TextWrapping="Wrap"/>

--- a/AccountDownloader/Views/CompleteView.axaml
+++ b/AccountDownloader/Views/CompleteView.axaml
@@ -12,8 +12,8 @@
   <StackPanel Spacing="10">
     <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" Text="{x:Static p:Resources.DownloadCompleteDescription}"/>
     <v:ProgressStatisticsView DataContext="{Binding ProgressStatistics}" HorizontalAlignment="Center"/>
-    <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" IsVisible="{Binding HasFailedRecords}" Text="{x:Static p:Resources.DownloadCompleteRecordFailureDescription}" />
-    <ScrollViewer Height="150" IsVisible="{Binding HasFailedRecords}" HorizontalAlignment="Center">
+    <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" IsVisible="{Binding FailedRecords.ShouldShow}" Text="{x:Static p:Resources.DownloadCompleteRecordFailureDescription}" />
+    <ScrollViewer Height="150" IsVisible="{Binding FailedRecords.ShouldShow}" HorizontalAlignment="Center">
       <v:FailedRecordsView DataContext="{Binding FailedRecords}" HorizontalAlignment="Center"/>
     </ScrollViewer>
     <TextBlock HorizontalAlignment="Center" Text="{x:Static p:Resources.WouldYouLikeToStartAnotherDownload}" TextWrapping="Wrap"/>

--- a/AccountDownloader/Views/CompleteView.axaml
+++ b/AccountDownloader/Views/CompleteView.axaml
@@ -12,7 +12,7 @@
   <StackPanel Spacing="10">
     <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" Text="{x:Static p:Resources.DownloadCompleteDescription}"/>
     <v:ProgressStatisticsView DataContext="{Binding ProgressStatistics}" HorizontalAlignment="Center"/>
-    <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" IsVisible="{Binding FailedRecords.ShouldShow}" Text="{x:Static p:Resources.DownloadCompleteRecordFailureDescription}" />
+    <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center" IsVisible="{Binding ShouldShowFailureMessage}" Text="{x:Static p:Resources.DownloadCompleteRecordFailureDescription}" />
     <ScrollViewer Height="150" IsVisible="{Binding FailedRecords.ShouldShow}" HorizontalAlignment="Center">
       <v:FailedRecordsView DataContext="{Binding FailedRecords}" HorizontalAlignment="Center"/>
     </ScrollViewer>

--- a/AccountDownloader/Views/Controls/FailedRecordsView.axaml
+++ b/AccountDownloader/Views/Controls/FailedRecordsView.axaml
@@ -10,8 +10,9 @@
              xmlns:vm="using:AccountDownloader.ViewModels"
              x:DataType="vm:FailedRecordsViewModel"
              x:CompileBindings="True">
-  <StackPanel>
-    <DataGrid ItemsSource="{Binding FailedRecords}" AutoGenerateColumns="False">
+  <StackPanel Spacing="4">
+    <TextBlock Text="{x:Static p:Resources.Records}" IsVisible="{Binding ShouldShowRecordFailures}"/>
+    <DataGrid ItemsSource="{Binding FailedRecords}" AutoGenerateColumns="False" IsVisible="{Binding ShouldShowRecordFailures}">
       <DataGrid.Columns>
           <DataGridTextColumn Header="{x:Static p:Resources.RecordId}"
                               Binding="{Binding RecordId}"
@@ -27,6 +28,25 @@
           <DataGridTextColumn Header="{x:Static p:Resources.FailureReason}"
                               Binding="{Binding FailureReason}"
                               Width="2*"/>
+      </DataGrid.Columns>
+    </DataGrid>
+    <TextBlock Text="{x:Static p:Resources.Assets}" IsVisible="{Binding ShouldShowAssetFailures}"/>
+    <DataGrid ItemsSource="{Binding FailedAssets}" AutoGenerateColumns="False" IsVisible="{Binding ShouldShowAssetFailures}">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="{x:Static p:Resources.AssetHash}"
+                            Binding="{Binding Hash}"
+                            Width="1*"/>
+        <DataGridTextColumn Header="{x:Static p:Resources.Owner}"
+                            Binding="{Binding OwnerId}"
+                            Width="1*"/>
+        <DataGridTextColumn Header="{x:Static p:Resources.Name}"
+                            Binding="{Binding RecordName}"
+                            Width="1*"/>
+        <DataGridTextColumn Header="{x:Static p:Resources.RecordPath}"
+                            Binding="{Binding RecordPath}"/>
+        <DataGridTextColumn Header="{x:Static p:Resources.FailureReason}"
+                            Binding="{Binding Reason}"
+                            Width="2*"/>
       </DataGrid.Columns>
     </DataGrid>
   </StackPanel>

--- a/AccountDownloader/Views/Controls/GroupsListView.axaml
+++ b/AccountDownloader/Views/Controls/GroupsListView.axaml
@@ -12,7 +12,7 @@
              x:CompileBindings="True">
 	<StackPanel>
 		<TextBlock Text="{x:Static p:Resources.NoGroupsFound}" IsVisible="{Binding !HasGroups}" />
-    <ScrollViewer VerticalScrollBarVisibility="Auto" Height="110" IsVisible="{Binding HasGroups}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Height="110" IsVisible="{Binding HasGroups}" AllowAutoHide="False">
 		  <ItemsRepeater ItemsSource="{Binding Groups}">
         <ItemsRepeater.Layout>
             <UniformGridLayout Orientation="Horizontal"

--- a/AccountDownloaderLibrary/AccountDownloadController.cs
+++ b/AccountDownloaderLibrary/AccountDownloadController.cs
@@ -311,7 +311,7 @@ namespace AccountDownloaderLibrary
                     lock (status)
                         status.AssetsUploaded++;
                 },
-                AssetMissing = hash => Status.RegisterMissingAsset(hash)
+                AssetFailure =  failure => Status.RegisterAssetFailure(failure)
             };
         }
 

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -11,13 +11,13 @@ namespace AccountDownloaderLibrary
     {
         readonly struct AssetJob
         {
-            public readonly string hash;
+            public readonly NeosDBAsset asset;
             public readonly IAccountDataGatherer source;
             public readonly RecordStatusCallbacks callbacks;
 
-            public AssetJob(string hash, IAccountDataGatherer source, RecordStatusCallbacks re)
+            public AssetJob(NeosDBAsset asset, IAccountDataGatherer source, RecordStatusCallbacks re)
             {
-                this.hash = hash;
+                this.asset = asset;
                 this.source = source;
                 this.callbacks = re;
             }
@@ -92,25 +92,25 @@ namespace AccountDownloaderLibrary
 
             DownloadProcessor = new ActionBlock<AssetJob>(async job =>
             {
-                var path = GetAssetPath(job.hash);
+                var path = GetAssetPath(job.asset.Hash);
 
                 if (File.Exists(path))
                     return;
 
                 try
                 {
-                    ProgressMessage?.Invoke($"Downloading asset {job.hash}");
+                    ProgressMessage?.Invoke($"Downloading asset {job.asset}");
 
-                    await job.source.DownloadAsset(job.hash, path).ConfigureAwait(false);
+                    await job.source.DownloadAsset(job.asset.Hash, path).ConfigureAwait(false);
 
                     job.callbacks.AssetUploaded();
 
-                    ProgressMessage?.Invoke($"Finished download {job.hash}");
+                    ProgressMessage?.Invoke($"Finished download {job.asset}");
                 }
                 catch (Exception ex)
                 {
-                    ProgressMessage?.Invoke($"Exception {job.hash}: " + ex);
-                    job.callbacks.AssetFailure(new AssetFailure(job.hash, ex.Message));
+                    ProgressMessage?.Invoke($"Exception {job.asset.Hash}: " + ex);
+                    job.callbacks.AssetFailure(new AssetFailure(job.asset.Hash, ex.Message));
                 }
             }, new ExecutionDataflowBlockOptions()
             {
@@ -248,7 +248,7 @@ namespace AccountDownloaderLibrary
 
             if (record.NeosDBManifest != null)
                 foreach (var asset in record.NeosDBManifest)
-                    ScheduleAsset(asset.Hash, source, statusCallbacks);
+                    ScheduleAsset(asset, source, statusCallbacks);
 
             return null;
         }
@@ -323,16 +323,16 @@ namespace AccountDownloaderLibrary
             return latest;
         }
 
-        void ScheduleAsset(string hash, IAccountDataGatherer store, RecordStatusCallbacks recordStatusCallbacks)
+        void ScheduleAsset(NeosDBAsset asset, IAccountDataGatherer store, RecordStatusCallbacks recordStatusCallbacks)
         {
-            if (!ScheduledAssets.Add(hash))
+            if (!ScheduledAssets.Add(asset.Hash))
                 return;
 
-            var job = new AssetJob(hash, store, recordStatusCallbacks);
+            var job = new AssetJob(asset, store, recordStatusCallbacks);
 
-            // TODO: I forget where we were meant to get this info from.
             var diff = new AssetDiff();
-            diff.Bytes = 0;
+            diff.State = AssetDiff.Diff.Added;
+            diff.Bytes = asset.Bytes;
 
             recordStatusCallbacks.AssetToUploadAdded(diff);
 

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -110,6 +110,7 @@ namespace AccountDownloaderLibrary
                 catch (Exception ex)
                 {
                     ProgressMessage?.Invoke($"Exception {job.hash}: " + ex);
+                    job.callbacks.AssetFailure(new AssetFailure(job.hash, ex.Message));
                 }
             }, new ExecutionDataflowBlockOptions()
             {

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -12,14 +12,16 @@ namespace AccountDownloaderLibrary
         readonly struct AssetJob
         {
             public readonly NeosDBAsset asset;
+            public readonly Record forRecord;
             public readonly IAccountDataGatherer source;
             public readonly RecordStatusCallbacks callbacks;
 
-            public AssetJob(NeosDBAsset asset, IAccountDataGatherer source, RecordStatusCallbacks re)
+            public AssetJob(Record forRecord, NeosDBAsset asset, IAccountDataGatherer source, RecordStatusCallbacks re)
             {
                 this.asset = asset;
                 this.source = source;
                 this.callbacks = re;
+                this.forRecord = forRecord;
             }
         }
 
@@ -248,7 +250,7 @@ namespace AccountDownloaderLibrary
 
             if (record.NeosDBManifest != null)
                 foreach (var asset in record.NeosDBManifest)
-                    ScheduleAsset(asset, source, statusCallbacks);
+                    ScheduleAsset(record, asset, source, statusCallbacks);
 
             return null;
         }
@@ -323,12 +325,12 @@ namespace AccountDownloaderLibrary
             return latest;
         }
 
-        void ScheduleAsset(NeosDBAsset asset, IAccountDataGatherer store, RecordStatusCallbacks recordStatusCallbacks)
+        void ScheduleAsset(Record record, NeosDBAsset asset, IAccountDataGatherer store, RecordStatusCallbacks recordStatusCallbacks)
         {
             if (!ScheduledAssets.Add(asset.Hash))
                 return;
 
-            var job = new AssetJob(asset, store, recordStatusCallbacks);
+            var job = new AssetJob(record, asset, store, recordStatusCallbacks);
 
             var diff = new AssetDiff();
             diff.State = AssetDiff.Diff.Added;

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -111,8 +111,8 @@ namespace AccountDownloaderLibrary
                 }
                 catch (Exception ex)
                 {
-                    ProgressMessage?.Invoke($"Exception {job.asset.Hash}: " + ex);
-                    job.callbacks.AssetFailure(new AssetFailure(job.asset.Hash, ex.Message));
+                    ProgressMessage?.Invoke($"Exception in fetching asset with Hash: {job.asset.Hash}: " + ex);
+                    job.callbacks.AssetFailure(new AssetFailure(job.asset.Hash, ex.Message, job.forRecord));
                 }
             }, new ExecutionDataflowBlockOptions()
             {

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -107,7 +107,7 @@ namespace AccountDownloaderLibrary
 
                     job.callbacks.AssetUploaded();
 
-                    ProgressMessage?.Invoke($"Finished download {job.asset}");
+                    ProgressMessage?.Invoke($"Finished download {job.asset.Hash}");
                 }
                 catch (Exception ex)
                 {

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -26,12 +26,24 @@ namespace AccountDownloaderLibrary
         }
     }
 
+    public readonly struct AssetFailure
+    {
+        public readonly string hash;
+        public readonly string reason;
+
+        public AssetFailure(string hash, string reason)
+        {
+            this.hash = hash;
+            this.reason = reason;
+        }
+    }
+
     public class RecordStatusCallbacks
     {
         public Action<AssetDiff> AssetToUploadAdded;
         public Action<long> BytesUploaded;
         public Action AssetUploaded;
-        public Action<string> AssetMissing;
+        public Action<AssetFailure> AssetFailure;
     }
 
     public interface IAccountDataGatherer

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -30,11 +30,13 @@ namespace AccountDownloaderLibrary
     {
         public readonly string hash;
         public readonly string reason;
+        public readonly Record forRecord;
 
-        public AssetFailure(string hash, string reason)
+        public AssetFailure(string hash, string reason, Record forRecord)
         {
             this.hash = hash;
             this.reason = reason;
+            this.forRecord = forRecord;
         }
     }
 

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -26,17 +26,21 @@ namespace AccountDownloaderLibrary
         }
     }
 
-    public readonly struct AssetFailure
+    public class AssetFailure
     {
-        public readonly string hash;
-        public readonly string reason;
-        public readonly Record forRecord;
+        public string Hash { get; }
+        public string Reason { get; }
+        public Record ForRecord { get; }
+
+        public string RecordName => ForRecord?.Name ?? "Unknown";
+        public string OwnerId => ForRecord?.OwnerId ?? "Unknown";
+        public string RecordPath => (ForRecord?.Path != string.Empty ? ForRecord?.Path : "Root/World") ?? "Unknown";
 
         public AssetFailure(string hash, string reason, Record forRecord)
         {
-            this.hash = hash;
-            this.reason = reason;
-            this.forRecord = forRecord;
+            this.Hash = hash;
+            this.Reason = reason;
+            this.ForRecord = forRecord;
         }
     }
 

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -288,7 +288,7 @@ namespace AccountDownloaderLibrary
             foreach(var failure in AssetFailures)
             {
                 var path = failure.forRecord.Path == string.Empty ? "ROOT or World" : failure.forRecord.Path;
-                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {} failed due to {failure.reason}.");
+                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {path} failed due to {failure.reason}.");
             }
             return b.ToString();
         }

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -236,6 +236,7 @@ namespace AccountDownloaderLibrary
             TotalAssetCount = count;
         }
 
+        //TODO: I want to move these out of this class
         public string GenerateReport()
         {
             //TODO: some sort of templating library
@@ -244,6 +245,7 @@ namespace AccountDownloaderLibrary
             b.AppendLine("----------------------");
             b.AppendLine($"Contacts: {DownloadedContactCount} / {TotalContactCount}");
             b.AppendLine($"Messages: {DownloadedMessageCount}");
+            b.AppendLine($"Assets: {TotalDownloadedAssetCount}/ {TotalAssetCount}");
             b.AppendLine(UserVariablesStatus.GenerateReport());
             b.AppendLine(UserRecordsStatus.GenerateReport());
 
@@ -264,7 +266,13 @@ namespace AccountDownloaderLibrary
                 b.AppendLine($"Total failed records: {TotalFailedRecordCount}");
             }
 
-
+            // ASSETS
+            if (AssetFailures.Count > 0)
+            {
+                b.AppendLine("Asset Failures");
+                b.AppendLine("----------------------");
+                b.Append(GenerateAssetFailuresReport());
+            }
 
 
             if (!string.IsNullOrEmpty(Error))
@@ -272,6 +280,16 @@ namespace AccountDownloaderLibrary
 
             return b.ToString();
 
+        }
+
+        private string GenerateAssetFailuresReport()
+        {
+            var b = new StringBuilder();
+            foreach(var failure in AssetFailures)
+            {
+                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {failure.forRecord.Path} failed due to {failure.reason}.");
+            }
+            return b.ToString();
         }
     }
 }

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -265,6 +265,8 @@ namespace AccountDownloaderLibrary
             }
 
 
+
+
             if (!string.IsNullOrEmpty(Error))
                 b.AppendLine("Error: " + Error);
 

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -81,7 +81,7 @@ namespace AccountDownloaderLibrary
         /// Assets that for some reason were missing on the source and could not be uploaded.
         /// Mainly for diagnostic purposes, but could be used in the future to try to relocate those.
         /// </summary>
-        public HashSet<string> MissingAssets { get; set; } = new HashSet<string>();
+        public List<AssetFailure> AssetFailures { get; set; } = new List<AssetFailure>();
 
         /// <summary>
         /// If the download failed
@@ -93,10 +93,10 @@ namespace AccountDownloaderLibrary
         /// </summary>
         public List<GroupDownloadStatus> GroupStatuses { get; set; } = new List<GroupDownloadStatus>();
 
-        public void RegisterMissingAsset(string hash)
+        public void RegisterAssetFailure(AssetFailure failure)
         {
-            lock (MissingAssets)
-                MissingAssets.Add(hash);
+            lock (AssetFailures)
+                AssetFailures.Add(failure);
         }
 
         public GroupDownloadStatus GetGroupStatus(string ownerId, string groupName)

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -287,7 +287,8 @@ namespace AccountDownloaderLibrary
             var b = new StringBuilder();
             foreach(var failure in AssetFailures)
             {
-                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {failure.forRecord.Path} failed due to {failure.reason}.");
+                var path = failure.forRecord.Path == string.Empty ? "ROOT or World" : failure.forRecord.Path;
+                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {} failed due to {failure.reason}.");
             }
             return b.ToString();
         }

--- a/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloadStatus.cs
@@ -287,8 +287,7 @@ namespace AccountDownloaderLibrary
             var b = new StringBuilder();
             foreach(var failure in AssetFailures)
             {
-                var path = failure.forRecord.Path == string.Empty ? "ROOT or World" : failure.forRecord.Path;
-                b.AppendLine($"{failure.hash} for {failure.forRecord.Name} at path {path} failed due to {failure.reason}.");
+                b.AppendLine($"{failure.Hash} for {failure.RecordName} at path {failure.RecordPath} owned by {failure.OwnerId} failed due to {failure.Reason}.");
             }
             return b.ToString();
         }


### PR DESCRIPTION
- Properly show Failed record downloads in the UI
- Log failed assets to the log file, including what they are a part of (need #17 stuff for better logging, will fix soon)
- Preparing to show failed assets in the UI too
- Failed assets UI table below records failures
- Disabled auto-hiding on all scrollbars I could find (a silly feature in avalonia)