### PR TITLE
fix(groups): use a more hardened method to display group filesize

### DIFF
--- a/AccountDownloader/App.axaml
+++ b/AccountDownloader/App.axaml
@@ -14,5 +14,6 @@
   <Application.Resources>
     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="#2C2C2C"/>
     <conv:ZeroConverter x:Key="ZeroConverter" />
+    <conv:BytesConverter x:Key="BytesConverter" />
   </Application.Resources>
 </Application>

--- a/AccountDownloader/Converters/BytesConverter.cs
+++ b/AccountDownloader/Converters/BytesConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using BaseX;
+
+namespace AccountDownloader.Converters;
+
+public class BytesConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null)
+            return "0 B";
+
+        var bytes = System.Convert.ToDouble(value);
+
+        return UnitFormatting.FormatBytes(bytes) ?? Res.Error;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/AccountDownloader/Services/CloudStorageService.cs
+++ b/AccountDownloader/Services/CloudStorageService.cs
@@ -1,9 +1,7 @@
 ﻿using CloudX.Shared;
 using ReactiveUI;
-using System;
-using BaseX;
 using ReactiveUI.Fody.Helpers;
-using System.Reactive.Linq;
+using System;
 
 namespace AccountDownloader.Services
 {
@@ -14,12 +12,6 @@ namespace AccountDownloader.Services
 
         [Reactive]
         public long TotalBytes { get; set; }
-
-        // See: https://www.reactiveui.net/docs/handbook/view-models/boilerplate-code
-        [ObservableAsProperty]
-        public string FormattedUsed { get;} = string.Empty;
-        [ObservableAsProperty]
-        public string FormattedTotal { get; } = string.Empty;
 
         public OwnerType OwnerType { get; set; }
         public string Id { get; set; }
@@ -54,11 +46,6 @@ namespace AccountDownloader.Services
         {
             Id = id;
             OwnerType = type;
-
-            // This essentially keeps Formatted* properties up to date when the non-formatted variants change
-            // See: https://www.reactiveui.net/docs/handbook/view-models/boilerplate-code
-            this.WhenAnyValue(x => x.UsedBytes).Select(x=> UnitFormatting.FormatBytes(x)).ToPropertyEx(this, x => x.FormattedUsed);
-            this.WhenAnyValue(x => x.TotalBytes).Select(x => UnitFormatting.FormatBytes(x)).ToPropertyEx(this, x => x.FormattedTotal);
         }
     }
     internal class CloudStorageService : IStorageService
@@ -96,7 +83,7 @@ namespace AccountDownloader.Services
                 storage = new ReactiveStorageRecord(groupId, OwnerType.Group);
                 storage.Update(groupInfo.UsedBytes, groupInfo.QuotaBytes);
             }
-                
+
             Interface.GroupUpdated += storage.Update;
 
             return storage;

--- a/AccountDownloader/Services/Interfaces/IAppCloudService.cs
+++ b/AccountDownloader/Services/Interfaces/IAppCloudService.cs
@@ -14,10 +14,6 @@ namespace AccountDownloader.Services
         public long UsedBytes { get; set; }
         public long TotalBytes { get; set; }
 
-        // TODO: Idealy Formatting should NOT be in the Model, we should write a converter
-        public string FormattedUsed { get; }
-        public string FormattedTotal { get; }
-
         public void Update(long used, long total);
 
         public string Id { get; set; }

--- a/AccountDownloader/Services/Interfaces/IAppCloudService.cs
+++ b/AccountDownloader/Services/Interfaces/IAppCloudService.cs
@@ -14,6 +14,7 @@ namespace AccountDownloader.Services
         public long UsedBytes { get; set; }
         public long TotalBytes { get; set; }
 
+        // TODO: Idealy Formatting should NOT be in the Model, we should write a converter
         public string FormattedUsed { get; }
         public string FormattedTotal { get; }
 

--- a/AccountDownloader/Utilities/DesignData.cs
+++ b/AccountDownloader/Utilities/DesignData.cs
@@ -33,10 +33,15 @@ namespace AccountDownloader
     }
     public class DesignStorageRecord : IStorageRecord
     {
+        public DesignStorageRecord()
+        {
+            Random rand = new Random();
+            FormattedUsed = rand.Next(1, 1000) + " GB";
+        }
         public long UsedBytes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public long TotalBytes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-        public string FormattedUsed => "20 GB";
+        public string FormattedUsed { get; set; }
 
         public string FormattedTotal => throw new NotImplementedException();
 

--- a/AccountDownloader/Utilities/DesignData.cs
+++ b/AccountDownloader/Utilities/DesignData.cs
@@ -36,14 +36,11 @@ namespace AccountDownloader
         public DesignStorageRecord()
         {
             Random rand = new Random();
-            FormattedUsed = rand.Next(1, 1000) + " GB";
+            UsedBytes = rand.Next(1000, 10000);
         }
-        public long UsedBytes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public long UsedBytes { get; set; }
         public long TotalBytes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-        public string FormattedUsed { get; set; }
-
-        public string FormattedTotal => throw new NotImplementedException();
 
         public string Id { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public OwnerType OwnerType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/AccountDownloader/ViewModels/DownloadSelectionViewModel.cs
+++ b/AccountDownloader/ViewModels/DownloadSelectionViewModel.cs
@@ -51,9 +51,6 @@ public class DownloadSelectionViewModel : ViewModelBase, IAccountDownloadConfig
     public string FilePath { get; set; } = "";
 
     [ObservableAsProperty]
-    public string FormattedRequiredBytes { get; } = string.Empty;
-
-    [ObservableAsProperty]
     public long RequiredBytes { get; } = 0;
 
     [ObservableAsProperty]
@@ -120,8 +117,6 @@ public class DownloadSelectionViewModel : ViewModelBase, IAccountDownloadConfig
                 bytes += p.Item2;
                 return bytes;
             });
-        // Format the bytes into a string
-        byteTotal.Select(x => UnitFormatting.FormatBytes(x)).ToPropertyEx(this, x => x.FormattedRequiredBytes);
 
         // Leave the bytes as a number
         byteTotal.ToPropertyEx(this, x => x.RequiredBytes);

--- a/AccountDownloader/Views/Controls/GroupsListView.axaml
+++ b/AccountDownloader/Views/Controls/GroupsListView.axaml
@@ -29,8 +29,8 @@
                   <StackPanel Orientation="Horizontal">
                       <TextBlock Text="{Binding Name}" Width="125" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
                   </StackPanel>
-                  <StackPanel Orientation="Horizontal">
-                    <TextBlock FontSize="12" Text="{Binding Storage.FormattedUsed, StringFormat='({0})'}"/>
+                  <StackPanel Orientation="Horizontal" Spacing="2">
+                    <TextBlock FontSize="12" Text="{Binding Storage.UsedBytes, Converter={StaticResource BytesConverter}}"/>
                     <TextBlock FontSize="12" Text="{x:Static p:Resources.GroupsAdminIndicator}" IsVisible="{Binding IsAdmin}"/>
                   </StackPanel>
               </StackPanel>

--- a/AccountDownloader/Views/DownloadSelectionView.axaml
+++ b/AccountDownloader/Views/DownloadSelectionView.axaml
@@ -35,7 +35,7 @@
       <TextBlock FontStyle="Italic" IsVisible="{Binding ShouldShowRequiredBytes}">
         <TextBlock.Text>
           <MultiBinding StringFormat="{x:Static p:Resources.StorageRequired}">
-              <Binding Path="FormattedRequiredBytes" />
+              <Binding Path="RequiredBytes" Converter="{StaticResource BytesConverter}"/>
           </MultiBinding>
         </TextBlock.Text>
       </TextBlock>


### PR DESCRIPTION
Also do the same for inventory file size.

Generically, we don't want ViewModels messing with presentation layer/view stuff that's what converters are for.

Anyway, remove this one source of that issue.