### PR TITLE
Re-architect the record retrieval to be more responsive and observable

### DIFF
--- a/AccountDownloaderLibrary/AccountDownloadController.cs
+++ b/AccountDownloaderLibrary/AccountDownloadController.cs
@@ -2,6 +2,8 @@
 using CloudX.Shared;
 using AccountDownloaderLibrary.Extensions;
 using AccountDownloaderLibrary.Interfaces;
+using System.Net;
+using System.Runtime.InteropServices;
 
 namespace AccountDownloaderLibrary
 {
@@ -348,15 +350,48 @@ namespace AccountDownloaderLibrary
             int count = 0;
 
             ActionBlock<Record> recordProcessing = new(
-                async r =>
+                async partialRecord =>
                 {
-                    Status.CurrentlyDownloadingItem = $"Record {r.Name} ({r.CombinedRecordId})";
+                    Status.CurrentlyDownloadingItem = $"Record {partialRecord.Name} ({partialRecord.CombinedRecordId})";
 
-                    var error = await Target.StoreRecord(r, Source, SetupCallbacks(status), Config.ForceOverwrite).ConfigureAwait(false);
+                    string lastError = null;
+
+                    Record fullRecord = null;
+
+                    // TODO: backoffs/too many requests
+                    // We need to re-download the record from its non-paginated source.
+                    // Which will include the manifest which we need
+                    for (int attempt = 0; attempt < 10; attempt++)
+                    {
+                        try
+                        {
+                            fullRecord = await Source.GetRecord(ownerId, partialRecord.RecordId).ConfigureAwait(false);
+
+                            if (fullRecord != null)
+                            {
+                                break;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            lastError = $"Could not get record: {ownerId}:{partialRecord.RecordId}. Result: {e.Message}";
+                        }
+                        break;
+                    }
+
+                    status.TotalRecordCount++;
+
+                    if (lastError != null || fullRecord == null)
+                    {
+                        HandleRecordError(status, partialRecord, lastError);
+                        return;
+                    }
+
+                    var error = await Target.StoreRecord(fullRecord, Source, SetupCallbacks(status), Config.ForceOverwrite).ConfigureAwait(false);
 
                     if (error != null)
                     {
-                        HandleRecordError(status, r, error);
+                        HandleRecordError(status, partialRecord, error);
                         return;
                     };
 
@@ -374,18 +409,21 @@ namespace AccountDownloaderLibrary
                     EnsureOrdered = false
                 });
 
-            await foreach (var record in Source.GetRecords(ownerId, latest).ConfigureAwait(false))
+            await foreach (var page in Source.GetRecords(ownerId, latest).ConfigureAwait(false))
             {
-                SetProgressMessage($"Queueing: {record.CombinedRecordId}");
+                
                 if (cancellationToken.IsCancellationRequested)
-                    return;
+                    break;
 
-                status.TotalRecordCount = Source.FetchedRecordCount(ownerId);
+                foreach (var record in page)
+                {
+                    SetProgressMessage($"Queueing: {record.CombinedRecordId}");
+                    if (!ProcessRecord(record))
+                        continue;
 
-                if (!ProcessRecord(record))
-                    continue;
-
-                recordProcessing.Post(record);
+                    recordProcessing.Post(record);
+                    string lastError = null;
+                }
 
                 // wait a bit if there's a lot of tasks
                 while (recordProcessing.InputCount > 16)

--- a/AccountDownloaderLibrary/AccountDownloadController.cs
+++ b/AccountDownloaderLibrary/AccountDownloadController.cs
@@ -378,8 +378,8 @@ namespace AccountDownloaderLibrary
                         }
                         break;
                     }
-
-                    status.TotalRecordCount++;
+                    lock (status)
+                        status.TotalRecordCount++;
 
                     if (lastError != null || fullRecord == null)
                     {

--- a/AccountDownloaderLibrary/Implementations/PaginatedRecordSearch.cs
+++ b/AccountDownloaderLibrary/Implementations/PaginatedRecordSearch.cs
@@ -1,0 +1,41 @@
+﻿using CloudX.Shared;
+
+namespace AccountDownloaderLibrary.Implementations;
+
+public class PaginatedRecordSearch<R> where R : class, IRecord, new()
+{
+    private SearchParameters searchParameters;
+
+    private CloudXInterface cloud;
+
+    public bool HasMoreResults { get; private set; }
+    public int Offset { get; private set; } = 0;
+
+    public PaginatedRecordSearch(SearchParameters searchParameters, CloudXInterface cloud)
+    {
+        this.searchParameters = searchParameters;
+        this.cloud = cloud;
+        HasMoreResults = true;
+    }
+
+    public async Task<IEnumerable<R>> Next()
+    {
+        searchParameters.Offset = Offset;
+        searchParameters.Count = searchParameters.Count;
+        CloudResult<SearchResults<R>> cloudResult = await cloud.FindRecords<R>(searchParameters).ConfigureAwait(continueOnCapturedContext: false);
+        if (cloudResult.IsOK)
+        {
+            Offset += searchParameters.Count;
+
+            cloud.RecordCache<R>().Cache(cloudResult.Entity.Records);
+
+            HasMoreResults = cloudResult.Entity.HasMoreResults;
+            return cloudResult.Entity.Records;
+        }
+        else
+        {
+            HasMoreResults = false;
+            return Enumerable.Empty<R>();
+        }
+    }
+}

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -65,8 +65,6 @@ namespace AccountDownloaderLibrary
         public string Username { get; }
 
         public event Action<string> ProgressMessage;
-
-        int FetchedRecordCount(string ownerId);
         int FetchedGroupCount { get; }
         Task Prepare(CancellationToken token);
         Task Complete();
@@ -85,7 +83,7 @@ namespace AccountDownloaderLibrary
         IAsyncEnumerable<GroupData> GetGroups();
         Task<List<MemberData>> GetMembers(string groupId);
         Task<Record> GetRecord(string ownerId, string recordId);
-        IAsyncEnumerable<Record> GetRecords(string ownerId, DateTime? from);
+        IAsyncEnumerable<IEnumerable<Record>> GetRecords(string ownerId, DateTime? from);
         User GetUserMetadata();
         Task<List<Friend>> GetContacts();
         IAsyncEnumerable<Message> GetMessages(string contactId, DateTime? from);


### PR DESCRIPTION
We had a method that was doing probably too many things:
1. Retrieving a list of records
2. Iterating over that list and re-fetching it to get the actual record data
3. Yielding each finalized record.

While compact, this meant we had no observability into what was going on. The method just awaited without any indication of what it was doing.

We've moved things around so that we can observe and react to pages of results as they come in. This also enabled us to retrieve the records in parralell. Which results in quite a large speed increase.