### PR TITLE
fix(featured): encode onlyFeatured only if the user specifies it

### DIFF
--- a/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
-using AccountDownloaderLibrary.Implementations;
+﻿using AccountDownloaderLibrary.Implementations;
 using AccountDownloaderLibrary.Mime;
+using AccountDownloaderLibrary.Models;
 using CloudX.Shared;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -146,7 +146,7 @@ namespace AccountDownloaderLibrary
 
         public virtual async IAsyncEnumerable<IEnumerable<Record>> GetRecords(string ownerId, DateTime? from)
         {
-            var searchParams = new SearchParameters
+            var searchParams = new AccountDownloaderSearchParameters
             {
                 ByOwner = ownerId,
                 Private = true,

--- a/AccountDownloaderLibrary/Implementations/PaginatedRecordSearch.cs
+++ b/AccountDownloaderLibrary/Implementations/PaginatedRecordSearch.cs
@@ -1,28 +1,35 @@
-﻿using CloudX.Shared;
+﻿using AccountDownloaderLibrary.Models;
+using CloudX.Shared;
 
 namespace AccountDownloaderLibrary.Implementations;
 
 public class PaginatedRecordSearch<R> where R : class, IRecord, new()
 {
-    private SearchParameters searchParameters;
+    private AccountDownloaderSearchParameters searchParameters;
 
     private CloudXInterface cloud;
 
     public bool HasMoreResults { get; private set; }
     public int Offset { get; private set; } = 0;
 
-    public PaginatedRecordSearch(SearchParameters searchParameters, CloudXInterface cloud)
+    public PaginatedRecordSearch(AccountDownloaderSearchParameters searchParameters, CloudXInterface cloud)
     {
         this.searchParameters = searchParameters;
         this.cloud = cloud;
         HasMoreResults = true;
     }
 
+    public Task<CloudResult<SearchResults<R>>> FindRecords(AccountDownloaderSearchParameters search)
+    {
+        return cloud.POST<SearchResults<R>>("api/records/pagedSearch", search);
+    }
+
     public async Task<IEnumerable<R>> Next()
     {
         searchParameters.Offset = Offset;
         searchParameters.Count = searchParameters.Count;
-        CloudResult<SearchResults<R>> cloudResult = await cloud.FindRecords<R>(searchParameters).ConfigureAwait(continueOnCapturedContext: false);
+        searchParameters.OnlyFeatured = null;
+        CloudResult<SearchResults<R>> cloudResult = await FindRecords(searchParameters).ConfigureAwait(continueOnCapturedContext: false);
         if (cloudResult.IsOK)
         {
             Offset += searchParameters.Count;

--- a/AccountDownloaderLibrary/Models/AccountDownloaderSearchParameters.cs
+++ b/AccountDownloaderLibrary/Models/AccountDownloaderSearchParameters.cs
@@ -1,0 +1,21 @@
+﻿using CloudX.Shared;
+using Newtonsoft.Json;
+using System.Text.Json.Serialization;
+
+namespace AccountDownloaderLibrary.Models;
+
+/**
+ * CloudX will filter on OnlyFeatured defaulting it to false, even if the user hasn't specified their preference.
+ * 
+ * This is rather silly. So we extend the class and re-define it as a nullable. This allows it to be ignored when sent to the cloud.
+ * 
+ * We'll have to log this as a bug for Neos to fix in CloudX too.
+ */
+
+[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+public class AccountDownloaderSearchParameters : SearchParameters
+{
+    [JsonProperty(PropertyName = "onlyFeatured", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("onlyFeatured")]
+    public new bool? OnlyFeatured { get; set; } = null;
+}

--- a/AcountDownloaderLibrary.Tests/AcountDownloaderLibrary.Tests.csproj
+++ b/AcountDownloaderLibrary.Tests/AcountDownloaderLibrary.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -14,6 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AcountDownloaderLibrary.Tests/SearchParameterTests.cs
+++ b/AcountDownloaderLibrary.Tests/SearchParameterTests.cs
@@ -1,0 +1,51 @@
+﻿using AccountDownloaderLibrary.Models;
+using Newtonsoft.Json;
+
+namespace AcountDownloaderLibrary.Tests;
+
+
+[TestClass]
+public class SearchParameterTests
+{
+    [TestMethod]
+    public void TestFeaturedNullNewtonSoft()
+    {
+        var ap = new AccountDownloaderSearchParameters();
+
+        ap.OnlyFeatured = null;
+
+        var jsonA = JsonConvert.SerializeObject(ap);
+        var deSerialize = JsonConvert.DeserializeObject<AccountDownloaderSearchParameters>(jsonA);
+
+        Assert.IsNull(deSerialize?.OnlyFeatured, "OnlyFeatured should only be present if the user included it");
+
+        ap.OnlyFeatured = false;
+        jsonA = JsonConvert.SerializeObject(ap);
+
+        deSerialize = JsonConvert.DeserializeObject<AccountDownloaderSearchParameters>(jsonA);
+
+        Assert.IsFalse(deSerialize?.OnlyFeatured, "OnlyFeatured was included and should be false");
+
+    }
+
+    [TestMethod]
+    public void TestFeaturedNullNET()
+    {
+        var ap = new AccountDownloaderSearchParameters();
+
+        ap.OnlyFeatured = null;
+
+        var jsonA = System.Text.Json.JsonSerializer.Serialize(ap);
+        var deSerialize = System.Text.Json.JsonSerializer.Deserialize<AccountDownloaderSearchParameters>(jsonA);
+
+        Assert.IsNull(deSerialize?.OnlyFeatured, "OnlyFeatured should only be present if the user included it");
+
+        ap.OnlyFeatured = false;
+        jsonA = JsonConvert.SerializeObject(ap);
+
+        deSerialize = JsonConvert.DeserializeObject<AccountDownloaderSearchParameters>(jsonA);
+
+        Assert.IsFalse(deSerialize?.OnlyFeatured, "OnlyFeatured was included and should be false");
+
+    }
+}


### PR DESCRIPTION
Neos' Cloud will only do filtering on the "featured" state of a world IF the search parameters include it.

Json serialization was including it because CloudX does not implement SearchParameters.OnlyFeatured as a nullable type. Our custom extension of this, resolves this problem.

fixes #192