### PR TITLE
Fix/weird datablock issues

### DIFF
--- a/AccountDownloader/Services/AppCloudService.cs
+++ b/AccountDownloader/Services/AppCloudService.cs
@@ -31,7 +31,9 @@ public class AppCloudService : IAppCloudService
     // Lets us see inside cloudx
     private void UniLog_OnLog(string obj)
     {
+#pragma warning disable CA2254 // We're exporting cloudx's log
         this.logger.LogDebug(obj);
+#pragma warning restore CA2254
     }
 
     public AuthenticationState AuthState { get; private set; }

--- a/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
@@ -72,8 +72,15 @@ namespace AccountDownloaderLibrary
 
                 if (result.IsOK)
                     return result.Entity;
-
-                await Task.Delay(TimeSpan.FromSeconds(attempt * 1.5), CancelToken).ConfigureAwait(false);
+                // https://stackoverflow.com/questions/20509158/taskcanceledexception-when-calling-task-delay-with-a-cancellationtoken-in-an-key
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(attempt * 1.5), CancelToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // we don't care
+                }
             }
 
             throw new Exception("Could not fetch contacts after several attempts. Result: " + result);
@@ -191,6 +198,7 @@ namespace AccountDownloaderLibrary
             return result?.Entity;
         }
 
+        //TODO: cancel token
         public virtual async Task<DateTime> GetLatestMessageTime(string contactId)
         {
             int delay = 50;

--- a/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/CloudAccountDataStore.cs
@@ -20,7 +20,7 @@ namespace AccountDownloaderLibrary
         public string UserId => Cloud.CurrentUser.Id;
         public string Username => Cloud.CurrentUser.Username;
 
-        private ILogger Logger;
+        private readonly ILogger Logger;
 
 #pragma warning disable CS0067 // The event 'CloudAccountDataStore.ProgressMessage' is never used
         public event Action<string> ProgressMessage;
@@ -28,12 +28,12 @@ namespace AccountDownloaderLibrary
 
         public int FetchedGroupCount { get; private set; }
 
-        public static DateTime EARLIEST_API_TIME = new(2016, 1, 1);
+        public static readonly DateTime EARLIEST_API_TIME = new(2016, 1, 1);
 
         private CancellationToken CancelToken;
 
         private const string DB_PREFIX = "neosdb:///";
-        private HttpClient WebClient = new HttpClient();
+        private readonly HttpClient WebClient = new();
 
         private readonly AccountDownloadConfig Config;
 
@@ -259,8 +259,9 @@ namespace AccountDownloaderLibrary
             return Task.CompletedTask;
         }
 
-        //TODO: Nullables
-        public async Task<IExtensionResult> GetAssetExtension(string hash)
+//TODO: Enabling Nullable here temporarily. Full Nullables
+#nullable enable
+        public async Task<IExtensionResult?> GetAssetExtension(string hash)
         {
             var result = await Cloud.GetAssetMime(hash);
             if (result.IsOK)
@@ -276,4 +277,5 @@ namespace AccountDownloaderLibrary
             return null;
         }
     }
+#nullable disable
 }

--- a/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Implementations/LocalAccountDataStore.cs
@@ -471,6 +471,7 @@ namespace AccountDownloaderLibrary
         public void Dispose()
         {
             ReleaseLocks();
+            DownloadProcessor.Complete();
             GC.SuppressFinalize(this);
         }
 

--- a/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
+++ b/AccountDownloaderLibrary/Interfaces/IAccountDataStore.cs
@@ -1,5 +1,6 @@
 ﻿using CloudX.Shared;
 
+#nullable enable
 namespace AccountDownloaderLibrary
 {
     public readonly struct GroupData
@@ -51,11 +52,11 @@ namespace AccountDownloaderLibrary
 
     public class RecordStatusCallbacks
     {
-        public Action<AssetDiff> AssetToUploadAdded;
-        public Action<long> BytesUploaded;
-        public Action<string> AssetUploaded;
-        public Action<AssetFailure> AssetFailure;
-        public Action<string> AssetSkipped;
+        public Action<AssetDiff>? AssetToUploadAdded;
+        public Action<long>? BytesUploaded;
+        public Action<string>? AssetUploaded;
+        public Action<AssetFailure>? AssetFailure;
+        public Action<string>? AssetSkipped;
     }
 
     public interface IAccountDataGatherer
@@ -75,7 +76,7 @@ namespace AccountDownloaderLibrary
 
         Task<long> GetAssetSize(string hash);
         Task<Stream> ReadAsset(string hash);
-        Task<IExtensionResult> GetAssetExtension(string hash);
+        Task<IExtensionResult?> GetAssetExtension(string hash);
 
         Task<List<CloudVariableDefinition>> GetVariableDefinitions(string ownerId);
         Task<CloudVariable> GetVariable(string ownerId, string path);
@@ -97,7 +98,7 @@ namespace AccountDownloaderLibrary
         Task StoreVariables(List<CloudVariable> variable);
         Task StoreGroup(Group group, Storage storage);
         Task StoreMember(Group group, Member member, Storage storage);
-        Task<string> StoreRecord(Record record, IAccountDataGatherer source, RecordStatusCallbacks statusCallbacks = null, bool forceConflictOverwrite = false);
+        Task<string> StoreRecord(Record record, IAccountDataGatherer source, RecordStatusCallbacks? statusCallbacks = null, bool forceConflictOverwrite = false);
         Task StoreUserMetadata(User user);
         Task StoreContact(Friend friend);
         Task StoreMessage(Message message);


### PR DESCRIPTION
- Our dataflow blocks used anonymous functions which is causing some mess in stack traces, moving them all to named functions means stack traces should be more readable
- Added nullable enabling annotations to various areas around our datablock use. This ensures they are hardened around nulls and null exceptions
- Prevented the asset downloader block from running once it is completed. This ideally should not happen but for some reason is inside https://github.com/GuVAnj8Gv3RJ/NeosAccountDownloader/issues/202, further resaearch is needed but this should help somewhat
- A bunch of code quality/style suggestions from visual studio have also been implemented. These are mostly small but we like not having them in the log so here they are.
- We also guard against Task.Delay throwing exceptions

fixes: #202 